### PR TITLE
Add donation links to static portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,32 @@
-## 👋 Welcome to my GitHub!
+# Joshi Minh · Portfolio
 
-Hi there! I'm Minh Nguyen, an enthusiastic developer focusing on tech and mechatronics.  Here you'll find my projects and contributions.
+This repository now contains a fully static version of my portfolio so it can be hosted without a build step (for example on GitHub Pages). The layout mirrors the original Next.js experience with sections for highlights, expertise, projects, and ways to connect.
 
-<div style="display: flex; gap: 10px; align: center;">
-  <img
-    src="https://github-readme-stats.vercel.app/api?username=joshiminh&theme=blueberry&show_icons=true&hide_border=true&count_private=true"
-    alt="joshiminh's Stats"
-    height="195px"
-  />
-  <img
-    src="https://github-readme-stats.vercel.app/api/top-langs/?username=joshiminh&theme=blueberry&show_icons=true&hide_border=true&layout=compact"
-    alt="joshiminh's Top Languages"
-    height="195px"
-  />
-</div>
+## Preview locally
+
+Open `index.html` directly in your browser or serve the site with any static HTTP server. For example:
+
+```bash
+python -m http.server 8000
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) and navigate to `index.html`.
+
+## Deploy on GitHub Pages
+
+1. Push the repository to GitHub.
+2. In the repository settings, open **Pages**.
+3. Choose the **main** branch and the `/ (root)` folder as the publishing source.
+4. Save and wait for GitHub Pages to publish the site at `https://<username>.github.io/<repository>/`.
+
+All assets are referenced relatively, so no additional configuration is needed. The site uses only static HTML, CSS, and JavaScript, plus the Lucide CDN for icons.
+
+## Structure
+
+```
+index.html         # markup for the entire portfolio
+assets/styles.css  # visual styling and responsive layout
+assets/script.js   # renders data-driven sections and icons
+```
+
+Feel free to customise the copy, colours, or add more projects by editing `assets/script.js`.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,12 @@ import { ProjectCard } from "@/components/project-card"
 import {
   Brain,
   Code,
+  Coffee,
   Layers,
   Palette,
   Rocket,
   Sparkles,
+  HeartHandshake,
   Wand2,
   Workflow,
   type LucideIcon,
@@ -66,6 +68,15 @@ type FocusArea = {
   title: string
   description: string
   icon: LucideIcon
+}
+
+type DonationLink = {
+  label: string
+  shortLabel: string
+  href: string
+  icon: LucideIcon
+  heroClass: string
+  footerClass: string
 }
 
 const createGradientStyle = (index: number, total: number) => {
@@ -153,6 +164,25 @@ const SOCIAL_BUTTONS = [
   { label: "Patreon", href: socialLinks.links.patreon, icon: PatreonIcon },
 ]
 
+const DONATION_LINKS: DonationLink[] = [
+  {
+    label: "Support on Ko-fi",
+    shortLabel: "Ko-fi",
+    href: "https://ko-fi.com/joshiminh",
+    icon: Coffee,
+    heroClass: "border-sky-400/60 bg-background/60 text-sky-200 hover:bg-sky-500/15 hover:text-white",
+    footerClass: "border-sky-400/60 bg-sky-500/10 text-sky-200 hover:bg-sky-500/20 hover:text-white",
+  },
+  {
+    label: "Join on Patreon",
+    shortLabel: "Patreon",
+    href: "https://www.patreon.com/c/u16604577",
+    icon: HeartHandshake,
+    heroClass: "border-rose-400/60 bg-background/60 text-rose-200 hover:bg-rose-500/15 hover:text-white",
+    footerClass: "border-rose-400/60 bg-rose-500/10 text-rose-200 hover:bg-rose-500/20 hover:text-white",
+  },
+]
+
 const CORE_VALUES = [
   "Software should feel like a conversation, not a chore.",
   "Learning in public keeps craft honest and energized.",
@@ -232,6 +262,26 @@ export default function Portfolio() {
                   >
                     <a href={social.href} target="_blank" rel="noopener noreferrer" aria-label={social.label}>
                       <Icon />
+                    </a>
+                  </Button>
+                )
+              })}
+            </div>
+            <div className="mt-6 flex flex-wrap items-center justify-center gap-3 lg:justify-start">
+              <span className="text-xs uppercase tracking-[0.32em] text-muted-foreground">Support</span>
+              {DONATION_LINKS.map((donation) => {
+                const Icon = donation.icon
+                return (
+                  <Button
+                    key={donation.shortLabel}
+                    variant="outline"
+                    size="sm"
+                    className={`border ${donation.heroClass}`}
+                    asChild
+                  >
+                    <a href={donation.href} target="_blank" rel="noopener noreferrer" aria-label={donation.label}>
+                      <Icon className="h-4 w-4" />
+                      <span>{donation.shortLabel}</span>
                     </a>
                   </Button>
                 )
@@ -423,18 +473,42 @@ export default function Portfolio() {
             </p>
             <p className="mt-2 text-sm text-muted-foreground">© 2025 Joshi Minh. Built with ❤️ and plenty of ☕.</p>
           </div>
-          <div className="flex flex-wrap justify-center gap-3">
-            {SOCIAL_BUTTONS.slice(0, 4).map((social) => {
-              const Icon = social.icon
-              return (
-                <Button key={social.label} variant="ghost" size="sm" className="hover:bg-accent/20" asChild>
-                  <a href={social.href} target="_blank" rel="noopener noreferrer">
-                    <Icon />
-                    <span className="ml-2 text-sm">{social.label}</span>
-                  </a>
-                </Button>
-              )
-            })}
+          <div className="flex flex-col items-center gap-5 md:items-end">
+            <div className="flex flex-wrap justify-center gap-3 md:justify-end">
+              {SOCIAL_BUTTONS.slice(0, 4).map((social) => {
+                const Icon = social.icon
+                return (
+                  <Button key={social.label} variant="ghost" size="sm" className="hover:bg-accent/20" asChild>
+                    <a href={social.href} target="_blank" rel="noopener noreferrer">
+                      <Icon />
+                      <span className="ml-2 text-sm">{social.label}</span>
+                    </a>
+                  </Button>
+                )
+              })}
+            </div>
+            <div className="flex flex-col items-center gap-2 md:items-end">
+              <span className="text-xs uppercase tracking-[0.32em] text-muted-foreground">Support</span>
+              <div className="flex flex-wrap justify-center gap-2 md:justify-end">
+                {DONATION_LINKS.map((donation) => {
+                  const Icon = donation.icon
+                  return (
+                    <Button
+                      key={`footer-${donation.shortLabel}`}
+                      variant="outline"
+                      size="sm"
+                      className={`border ${donation.footerClass}`}
+                      asChild
+                    >
+                      <a href={donation.href} target="_blank" rel="noopener noreferrer">
+                        <Icon className="h-4 w-4" />
+                        <span>{donation.shortLabel}</span>
+                      </a>
+                    </Button>
+                  )
+                })}
+              </div>
+            </div>
           </div>
         </div>
       </footer>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,435 @@
+const heroHighlights = [
+  {
+    title: "Joyful digital products",
+    description:
+      "Blending design and engineering to deliver experiences that feel personal, polished, and fast.",
+    icon: "sparkles",
+  },
+  {
+    title: "AI-native workflows",
+    description: "Prototyping copilots and automation that take teams from idea to production quickly.",
+    icon: "workflow",
+  },
+]
+
+const focusAreas = [
+  {
+    title: "Creative AI copilots",
+    description: "Exploring interfaces that amplify imagination and unlock new creative rituals.",
+    icon: "wand-2",
+  },
+  {
+    title: "Design systems that scale",
+    description: "Establishing cohesive visual languages and component libraries that keep teams aligned.",
+    icon: "layers",
+  },
+  {
+    title: "Delightful developer experience",
+    description: "Automating the boring parts so builders can focus on shipping meaningful value.",
+    icon: "rocket",
+  },
+]
+
+const expertiseAreas = [
+  {
+    title: "Software Engineering",
+    description: "Building resilient, scalable applications with thoughtful architecture and clean code.",
+    icon: "code",
+    gradient: "linear-gradient(90deg, rgba(56,189,248,0.9), rgba(99,102,241,0.9))",
+    tags: ["Python", "Java", "JavaScript", "HTML", "CSS"],
+  },
+  {
+    title: "AI Development",
+    description: "Designing intelligent systems and bringing machine learning ideas into joyful products.",
+    icon: "brain",
+    gradient: "linear-gradient(90deg, rgba(217,70,239,0.9), rgba(129,140,248,0.9))",
+    tags: ["Machine Learning", "Python", "TensorFlow", "AI SDK"],
+  },
+  {
+    title: "Design & Experience",
+    description: "Crafting beautiful, intuitive interfaces where aesthetics meet accessible, human-centered UX.",
+    icon: "palette",
+    gradient: "linear-gradient(90deg, rgba(244,114,182,0.95), rgba(251,191,36,0.95))",
+    tags: ["UI/UX", "CSS", "HTML", "Responsive Design"],
+  },
+]
+
+const projectCards = [
+  {
+    title: "Markbase",
+    description: "An indie SaaS for capturing build-in-public notes with AI-powered summaries and publishing tools.",
+    url: "https://markbase-joshiminh.vercel.app/",
+    favicon: "https://www.google.com/s2/favicons?domain=markbase-joshiminh.vercel.app&sz=32",
+  },
+  {
+    title: "Watchbase",
+    description: "Curated catalog of favourite timepieces with wishlists, notes, and delightful watch nerd details.",
+    url: "https://watchbase.vercel.app/",
+    favicon: "https://www.google.com/s2/favicons?domain=watchbase.vercel.app&sz=32",
+  },
+]
+
+const workStyle = [
+  {
+    title: "Product loops",
+    body: "Discover → prototype → learn → refine. Short feedback loops keep momentum high.",
+  },
+  {
+    title: "Collaborative energy",
+    body: "I love jamming with designers, storytellers, and engineers to co-create resonant work.",
+  },
+  {
+    title: "Beyond the screen",
+    body: "Workshops, content, and community events keep me exploring new perspectives.",
+  },
+]
+
+const workChips = ["AI", "Full-stack", "Design Systems", "Community"]
+
+const focusChips = ["Product thinking", "Rapid prototyping", "Community-first"]
+
+const coreValues = [
+  "Software should feel like a conversation, not a chore.",
+  "Learning in public keeps craft honest and energized.",
+  "Great systems elevate the humans who rely on them.",
+]
+
+const socialLinks = [
+  {
+    label: "GitHub",
+    url: "https://github.com/JoshiMinh",
+    icon: githubIcon,
+  },
+  {
+    label: "LinkedIn",
+    url: "https://www.linkedin.com/in/nguyen-binh-minh-jm",
+    icon: linkedinIcon,
+  },
+  {
+    label: "X/Twitter",
+    url: "https://x.com/js_minh",
+    icon: xIcon,
+  },
+  {
+    label: "YouTube",
+    url: "https://www.youtube.com/channel/UCkt3Mhwb3bduqwtRDZtjvsg",
+    icon: youtubeIcon,
+  },
+  {
+    label: "Patreon",
+    url: "https://www.patreon.com/c/u16604577",
+    icon: patreonIcon,
+  },
+]
+
+const donationLinks = [
+  {
+    label: "Support on Ko-fi",
+    shortLabel: "Ko-fi",
+    url: "https://ko-fi.com/joshiminh",
+    icon: "coffee",
+    heroClass: "support-button--kofi",
+    footerClass: "site-footer__support-link--kofi",
+  },
+  {
+    label: "Join on Patreon",
+    shortLabel: "Patreon",
+    url: "https://www.patreon.com/c/u16604577",
+    icon: "heart-handshake",
+    heroClass: "support-button--patreon",
+    footerClass: "site-footer__support-link--patreon",
+  },
+]
+
+function githubIcon() {
+  return `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.387.6.111.82-.261.82-.577 0-.287-.01-1.244-.015-2.444-3.338.724-4.043-1.61-4.043-1.61-.546-1.385-1.333-1.754-1.333-1.754-1.089-.745.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.807 1.305 3.492.998.108-.775.418-1.305.76-1.605-2.665-.303-5.466-1.335-5.466-5.93 0-1.31.469-2.381 1.236-3.221-.124-.304-.536-1.524.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 0 1 3.003-.404c1.02.005 2.044.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.653 1.653.241 2.873.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.807 5.624-5.479 5.921.43.372.823 1.105.823 2.226 0 1.606-.014 2.898-.014 3.293 0 .319.216.694.825.576C20.565 22.092 24 17.592 24 12.297 24 5.373 18.627 0 12 .297Z"
+      ></path>
+    </svg>
+  `
+}
+
+function linkedinIcon() {
+  return `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452z"
+      ></path>
+    </svg>
+  `
+}
+
+function xIcon() {
+  return `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298z"
+      ></path>
+    </svg>
+  `
+}
+
+function youtubeIcon() {
+  return `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93-.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"
+      ></path>
+    </svg>
+  `
+}
+
+function patreonIcon() {
+  return `
+    <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path
+        fill="currentColor"
+        d="M0 .48v23.04h4.22V.48zm15.385 0c-4.764 0-8.641 3.88-8.641 8.65 0 4.755 3.877 8.623 8.641 8.623 4.75 0 8.615-3.868 8.615-8.623C24 4.36 20.136.48 15.385.48z"
+      ></path>
+    </svg>
+  `
+}
+
+function createGradient(index, total) {
+  const hueStart = 220
+  const hueEnd = 320
+  const steps = Math.max(total - 1, 1)
+  const hue = hueStart + (index / steps) * (hueEnd - hueStart)
+  return `linear-gradient(135deg, hsl(${hue}, 70%, 60%) 0%, hsl(${hue + 20}, 70%, 60%) 100%)`
+}
+
+function formatUrl(urlString) {
+  try {
+    const url = new URL(urlString)
+    const hostname = url.hostname.replace(/^www\./, "")
+    const segments = url.pathname.split("/").filter(Boolean).slice(0, 3)
+    return { hostname, segments }
+  } catch (error) {
+    return { hostname: urlString, segments: [] }
+  }
+}
+
+function renderHighlights() {
+  const container = document.getElementById("hero-highlights")
+  heroHighlights.forEach((item) => {
+    const card = document.createElement("article")
+    card.className = "highlight-card"
+    card.innerHTML = `
+      <span class="highlight-card__icon" aria-hidden="true">
+        <i data-lucide="${item.icon}"></i>
+      </span>
+      <div class="highlight-card__body">
+        <h3>${item.title}</h3>
+        <p>${item.description}</p>
+      </div>
+    `
+    container.appendChild(card)
+  })
+}
+
+function renderFocusAreas() {
+  const list = document.getElementById("focus-areas")
+  focusAreas.forEach((item) => {
+    const row = document.createElement("div")
+    row.className = "focus-row"
+    row.innerHTML = `
+      <span class="focus-row__icon" aria-hidden="true">
+        <i data-lucide="${item.icon}"></i>
+      </span>
+      <div class="focus-row__body">
+        <h3>${item.title}</h3>
+        <p>${item.description}</p>
+      </div>
+    `
+    list.appendChild(row)
+  })
+
+  const chipContainer = document.getElementById("focus-chips")
+  focusChips.forEach((chip) => {
+    const span = document.createElement("span")
+    span.className = "chip"
+    span.textContent = chip
+    chipContainer.appendChild(span)
+  })
+}
+
+function renderExpertise() {
+  const grid = document.getElementById("expertise-grid")
+  expertiseAreas.forEach((area) => {
+    const card = document.createElement("article")
+    card.className = "expertise-card"
+    card.style.setProperty("--gradient", area.gradient)
+    card.innerHTML = `
+      <span class="expertise-card__icon" aria-hidden="true">
+        <i data-lucide="${area.icon}"></i>
+      </span>
+      <div>
+        <h3>${area.title}</h3>
+        <p>${area.description}</p>
+      </div>
+      <div class="badge-row"></div>
+    `
+
+    const badgeRow = card.querySelector(".badge-row")
+    area.tags.forEach((tag, index) => {
+      const badge = document.createElement("span")
+      badge.className = "badge"
+      badge.style.background = createGradient(index, area.tags.length)
+      badge.textContent = tag
+      badgeRow.appendChild(badge)
+    })
+
+    grid.appendChild(card)
+  })
+}
+
+function renderProjects() {
+  const grid = document.getElementById("project-grid")
+  projectCards.forEach((project) => {
+    const { hostname, segments } = formatUrl(project.url)
+    const card = document.createElement("a")
+    card.className = "project-card"
+    card.href = project.url
+    card.target = "_blank"
+    card.rel = "noopener noreferrer"
+
+    const tags = segments.length
+      ? segments.map((segment) => segment.replace(/-/g, " "))
+      : ["Live project"]
+
+    card.innerHTML = `
+      <div class="project-card__header">
+        <div class="project-card__info">
+          <span class="project-card__favicon" aria-hidden="true">
+            <img src="${project.favicon}" alt="" loading="lazy" />
+          </span>
+          <div>
+            <h3>${project.title}</h3>
+            <div class="project-card__domain">${hostname}</div>
+          </div>
+        </div>
+        <span class="project-card__cta">Visit <i data-lucide="external-link"></i></span>
+      </div>
+      <p class="project-card__description">${project.description}</p>
+      <div class="project-card__tags"></div>
+    `
+
+    const tagContainer = card.querySelector(".project-card__tags")
+    tags.forEach((tag) => {
+      const span = document.createElement("span")
+      span.className = "project-card__tag"
+      span.textContent = tag
+      tagContainer.appendChild(span)
+    })
+
+    grid.appendChild(card)
+  })
+}
+
+function renderSocialButtons() {
+  const socialContainer = document.getElementById("social-buttons")
+  socialLinks.forEach((item) => {
+    const link = document.createElement("a")
+    link.className = "social-button"
+    link.href = item.url
+    link.target = "_blank"
+    link.rel = "noopener noreferrer"
+    link.setAttribute("aria-label", item.label)
+    link.innerHTML = item.icon()
+    socialContainer.appendChild(link)
+  })
+
+  const footer = document.getElementById("footer-links")
+  socialLinks.slice(0, 4).forEach((item) => {
+    const link = document.createElement("a")
+    link.className = "site-footer__link"
+    link.href = item.url
+    link.target = "_blank"
+    link.rel = "noopener noreferrer"
+    link.innerHTML = `${item.icon()}<span>${item.label}</span>`
+    footer.appendChild(link)
+  })
+}
+
+function renderDonations() {
+  const donationContainer = document.getElementById("donation-buttons")
+  const footerContainer = document.getElementById("footer-donations")
+
+  donationLinks.forEach((item) => {
+    if (donationContainer) {
+      const link = document.createElement("a")
+      link.className = `support-button ${item.heroClass}`
+      link.href = item.url
+      link.target = "_blank"
+      link.rel = "noopener noreferrer"
+      link.setAttribute("aria-label", item.label)
+      link.title = item.label
+      link.innerHTML = `<i data-lucide="${item.icon}"></i><span>${item.shortLabel}</span>`
+      donationContainer.appendChild(link)
+    }
+
+    if (footerContainer) {
+      const footerLink = document.createElement("a")
+      footerLink.className = `site-footer__support-link ${item.footerClass}`
+      footerLink.href = item.url
+      footerLink.target = "_blank"
+      footerLink.rel = "noopener noreferrer"
+      footerLink.setAttribute("aria-label", item.label)
+      footerLink.title = item.label
+      footerLink.innerHTML = `<i data-lucide="${item.icon}"></i><span>${item.shortLabel}</span>`
+      footerContainer.appendChild(footerLink)
+    }
+  })
+}
+
+function renderWorkStyle() {
+  const list = document.getElementById("work-style")
+  workStyle.forEach((item) => {
+    const entry = document.createElement("div")
+    entry.className = "work-card__item"
+    entry.innerHTML = `<h4>${item.title}</h4><p>${item.body}</p>`
+    list.appendChild(entry)
+  })
+
+  const chipContainer = document.getElementById("work-chips")
+  workChips.forEach((chip) => {
+    const span = document.createElement("span")
+    span.className = "work-card__chip"
+    span.textContent = chip
+    chipContainer.appendChild(span)
+  })
+}
+
+function renderCoreValues() {
+  const list = document.getElementById("core-values")
+  coreValues.forEach((value) => {
+    const li = document.createElement("li")
+    const text = document.createElement("span")
+    text.textContent = value
+    li.appendChild(text)
+    list.appendChild(li)
+  })
+}
+
+function initPage() {
+  renderHighlights()
+  renderFocusAreas()
+  renderExpertise()
+  renderProjects()
+  renderSocialButtons()
+  renderDonations()
+  renderWorkStyle()
+  renderCoreValues()
+
+  if (window.lucide && typeof window.lucide.createIcons === "function") {
+    window.lucide.createIcons()
+  }
+}
+
+document.addEventListener("DOMContentLoaded", initPage)

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,1001 @@
+:root {
+  color-scheme: dark;
+  --background: #06060a;
+  --surface: rgba(18, 18, 28, 0.85);
+  --surface-strong: rgba(22, 22, 32, 0.9);
+  --border: rgba(120, 120, 180, 0.3);
+  --accent: #8b5cf6;
+  --accent-soft: rgba(139, 92, 246, 0.16);
+  --accent-2: rgba(56, 189, 248, 0.6);
+  --text: #f4f4ff;
+  --muted: rgba(226, 232, 240, 0.75);
+  --muted-strong: rgba(148, 163, 184, 0.6);
+  --card-shadow: 0 30px 60px -40px rgba(139, 92, 246, 0.55);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(30, 41, 59, 0.45), rgba(6, 6, 10, 1) 60%),
+    linear-gradient(160deg, rgba(6, 6, 10, 0.92), rgba(11, 11, 20, 1));
+  color: var(--text);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+.page {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero {
+  position: relative;
+  padding: 5rem clamp(1rem, 5vw, 3rem) clamp(3rem, 8vw, 6rem);
+}
+
+.hero__background {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.blur-ball {
+  position: absolute;
+  filter: blur(140px);
+  border-radius: 999px;
+  opacity: 0.8;
+}
+
+.blur-ball--primary {
+  width: 30rem;
+  height: 30rem;
+  top: -20%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(56, 189, 248, 0.45);
+}
+
+.blur-ball--secondary {
+  width: 24rem;
+  height: 24rem;
+  left: -12rem;
+  bottom: -30%;
+  background: rgba(56, 189, 248, 0.25);
+}
+
+.blur-ball--accent {
+  width: 22rem;
+  height: 22rem;
+  right: -16rem;
+  top: 40%;
+  background: rgba(236, 72, 153, 0.3);
+}
+
+.hero__content {
+  position: relative;
+  display: grid;
+  gap: clamp(2rem, 6vw, 4.5rem);
+  align-items: stretch;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  text-align: center;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  align-self: center;
+  font-size: 0.85rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  background: rgba(129, 140, 248, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.status-pill__dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(139, 92, 246, 0.12);
+  animation: pulse 2.4s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.35);
+    opacity: 0.6;
+  }
+}
+
+.hero__title {
+  font-size: clamp(2.7rem, 5vw, 4.5rem);
+  line-height: 1.05;
+  font-weight: 600;
+  margin: 0;
+}
+
+.text-gradient {
+  background: linear-gradient(135deg, #38bdf8, #a855f7 60%, #f472b6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero__lead {
+  margin: 0 auto;
+  max-width: 45ch;
+  color: var(--muted);
+  font-size: clamp(1.05rem, 2.2vw, 1.25rem);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease;
+}
+
+.button--primary {
+  color: #fff;
+  background: linear-gradient(135deg, #38bdf8, #a855f7 70%, #ec4899);
+  box-shadow: 0 20px 40px -25px rgba(236, 72, 153, 0.75);
+  border: 0;
+}
+
+.button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 45px -25px rgba(236, 72, 153, 0.9);
+}
+
+.button--outline {
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text);
+}
+
+.button--outline:hover {
+  background: rgba(148, 163, 184, 0.08);
+  transform: translateY(-1px);
+}
+
+.button .icon,
+.button i[data-lucide] {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.hero__highlights {
+  display: grid;
+  gap: 1rem;
+}
+
+.highlight-card {
+  display: flex;
+  gap: 1rem;
+  border-radius: 1.75rem;
+  border: 1px solid rgba(120, 120, 180, 0.35);
+  background: rgba(12, 12, 18, 0.72);
+  padding: 1.25rem;
+  backdrop-filter: blur(14px);
+  transition: border 0.25s ease, transform 0.25s ease;
+}
+
+.highlight-card:hover {
+  border-color: rgba(168, 85, 247, 0.6);
+  transform: translateY(-2px);
+}
+
+.highlight-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 1.2rem;
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.highlight-card__body h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.highlight-card__body p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.hero__social {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero__social-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.35em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.hero__support {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1.25rem;
+}
+
+.hero__support-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.hero__support-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.support-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.9rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.support-button i[data-lucide] {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.support-button--kofi {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.14);
+  color: #bae6fd;
+}
+
+.support-button--kofi:hover {
+  border-color: rgba(56, 189, 248, 0.75);
+  background: rgba(56, 189, 248, 0.24);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.support-button--patreon {
+  border-color: rgba(251, 113, 133, 0.45);
+  background: rgba(251, 113, 133, 0.14);
+  color: #fecdd3;
+}
+
+.support-button--patreon:hover {
+  border-color: rgba(251, 113, 133, 0.7);
+  background: rgba(251, 113, 133, 0.24);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.social-button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.04);
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.social-button:hover {
+  border-color: rgba(139, 92, 246, 0.65);
+  background: rgba(139, 92, 246, 0.16);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.hero__card {
+  position: relative;
+}
+
+.feature-card {
+  position: relative;
+  padding: clamp(1.8rem, 4vw, 2.4rem);
+  border-radius: 2.25rem;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  backdrop-filter: blur(18px);
+  overflow: hidden;
+  box-shadow: var(--card-shadow);
+}
+
+.feature-card__glow {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), transparent 40%, rgba(236, 72, 153, 0.18));
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.feature-card__header {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.feature-card__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.feature-card__header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.feature-card__list {
+  position: relative;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.focus-row {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.9rem 1rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(120, 120, 180, 0.35);
+  background: rgba(12, 12, 18, 0.68);
+}
+
+.focus-row__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 1rem;
+  background: rgba(56, 189, 248, 0.14);
+  color: #38bdf8;
+  flex-shrink: 0;
+}
+
+.focus-row__body h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.focus-row__body p {
+  margin: 0.3rem 0 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.feature-card__chips {
+  margin-top: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.section {
+  position: relative;
+  padding: clamp(3rem, 8vw, 6rem) clamp(1rem, 5vw, 3rem);
+}
+
+.section__intro {
+  max-width: 42rem;
+  margin: 0 auto;
+  text-align: center;
+  display: grid;
+  gap: 1rem;
+}
+
+.section__intro h2 {
+  margin: 0;
+  font-size: clamp(2.1rem, 4vw, 2.8rem);
+}
+
+.section__intro p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.card-grid {
+  margin-top: clamp(2rem, 6vw, 3.5rem);
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.expertise-card,
+.project-card,
+.work-card,
+.feature-card {
+  border: 1px solid var(--border);
+}
+
+.expertise-card {
+  position: relative;
+  padding: 2rem;
+  border-radius: 1.75rem;
+  background: var(--surface);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 1.25rem;
+  overflow: hidden;
+}
+
+.expertise-card::before {
+  content: "";
+  position: absolute;
+  inset: 1.2rem 1.8rem auto;
+  height: 1px;
+  background: var(--gradient, rgba(139, 92, 246, 0.4));
+  opacity: 0.8;
+}
+
+.expertise-card__icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1.4rem;
+  background: rgba(139, 92, 246, 0.12);
+  color: var(--accent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.expertise-card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.expertise-card p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.03em;
+  font-weight: 500;
+  color: #fff;
+  border: 0;
+}
+
+.section--projects {
+  background: linear-gradient(180deg, rgba(12, 12, 20, 0.35), rgba(6, 6, 10, 0.95));
+  border-block: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  letter-spacing: 0.3em;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: rgba(56, 189, 248, 0.12);
+  color: #38bdf8;
+  margin: 0 auto;
+}
+
+.card-grid--projects {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  position: relative;
+  border-radius: 1.75rem;
+  background: rgba(15, 15, 22, 0.8);
+  padding: 1.75rem;
+  display: grid;
+  gap: 1.25rem;
+  transition: transform 0.25s ease, border 0.25s ease, box-shadow 0.25s ease;
+  overflow: hidden;
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(139, 92, 246, 0.6);
+  box-shadow: 0 30px 65px -40px rgba(139, 92, 246, 0.7);
+}
+
+.project-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.project-card__info {
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+}
+
+.project-card__favicon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid rgba(120, 120, 180, 0.35);
+  background: rgba(12, 12, 18, 0.65);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-card__favicon img {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.project-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.project-card__domain {
+  font-size: 0.75rem;
+  color: var(--muted-strong);
+  margin-top: 0.3rem;
+}
+
+.project-card__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.project-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.project-card__tag {
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid rgba(120, 120, 180, 0.35);
+  background: rgba(12, 12, 18, 0.55);
+  font-size: 0.7rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.project-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.section__note {
+  margin-top: 1.5rem;
+  text-align: center;
+  color: var(--muted-strong);
+  font-size: 0.85rem;
+}
+
+.about {
+  display: grid;
+  gap: clamp(2rem, 6vw, 3rem);
+  max-width: 1100px;
+  margin: 0 auto;
+  align-items: start;
+}
+
+.about__text {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.about__text p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.about__values {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.about__values li {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+  color: var(--muted);
+}
+
+.about__values::before,
+.about__values::after {
+  display: none;
+}
+
+.about__values span::before {
+  content: "";
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  background: var(--accent);
+  border-radius: 50%;
+  margin-right: 0.8rem;
+  box-shadow: 0 0 0 6px rgba(139, 92, 246, 0.12);
+}
+
+.work-card {
+  position: relative;
+  padding: clamp(1.6rem, 4vw, 2.2rem);
+  border-radius: 1.9rem;
+  background: var(--surface-strong);
+  backdrop-filter: blur(18px);
+  display: grid;
+  gap: 1.25rem;
+  overflow: hidden;
+}
+
+.work-card__glow {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(236, 72, 153, 0.12), transparent 50%, rgba(56, 189, 248, 0.16));
+  pointer-events: none;
+}
+
+.work-card header {
+  position: relative;
+}
+
+.work-card header h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.4rem;
+}
+
+.work-card header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.work-card__list {
+  position: relative;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.work-card__item {
+  border-radius: 1.4rem;
+  border: 1px solid rgba(120, 120, 180, 0.35);
+  background: rgba(10, 10, 16, 0.6);
+  padding: 1rem;
+}
+
+.work-card__item h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.work-card__item p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.work-card__chips {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.work-card__chip {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.45rem 0.9rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: clamp(2.5rem, 6vw, 3.5rem) clamp(1rem, 5vw, 3rem);
+  background: rgba(8, 8, 12, 0.95);
+}
+
+.site-footer__content {
+  display: grid;
+  gap: 1.5rem;
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.site-footer__actions {
+  display: grid;
+  gap: 1rem;
+  justify-items: center;
+}
+
+.site-footer__meta {
+  margin-top: 0.5rem;
+  color: var(--muted-strong);
+  font-size: 0.85rem;
+}
+
+.site-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.site-footer__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--muted);
+  font-size: 0.85rem;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.site-footer__link:hover {
+  border-color: rgba(56, 189, 248, 0.4);
+  background: rgba(56, 189, 248, 0.18);
+  color: #fff;
+  transform: translateY(-2px);
+}
+
+.site-footer__donate {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: center;
+}
+
+.site-footer__donate-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--muted-strong);
+}
+
+.site-footer__donate-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.6rem;
+}
+
+.site-footer__support-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.8rem;
+  color: var(--muted);
+  background: rgba(255, 255, 255, 0.04);
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.site-footer__support-link i[data-lucide] {
+  width: 1rem;
+  height: 1rem;
+}
+
+.site-footer__support-link--kofi {
+  border-color: rgba(56, 189, 248, 0.45);
+  background: rgba(56, 189, 248, 0.16);
+  color: #bae6fd;
+}
+
+.site-footer__support-link--kofi:hover {
+  border-color: rgba(56, 189, 248, 0.75);
+  background: rgba(56, 189, 248, 0.25);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+.site-footer__support-link--patreon {
+  border-color: rgba(251, 113, 133, 0.45);
+  background: rgba(251, 113, 133, 0.16);
+  color: #fecdd3;
+}
+
+.site-footer__support-link--patreon:hover {
+  border-color: rgba(251, 113, 133, 0.7);
+  background: rgba(251, 113, 133, 0.26);
+  color: #fff;
+  transform: translateY(-1px);
+}
+
+@media (min-width: 768px) {
+  .hero__content {
+    grid-template-columns: 1.15fr 0.85fr;
+    text-align: left;
+  }
+
+  .hero__text {
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .status-pill {
+    align-self: flex-start;
+  }
+
+  .hero__lead {
+    margin-inline: 0;
+  }
+
+  .hero__actions {
+    justify-content: flex-start;
+  }
+
+  .hero__social {
+    justify-content: flex-start;
+  }
+
+  .hero__support {
+    justify-content: flex-start;
+  }
+
+  .hero__support-buttons {
+    justify-content: flex-start;
+  }
+
+  .hero__highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .site-footer__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    text-align: left;
+    align-items: center;
+  }
+
+  .site-footer__actions {
+    justify-items: end;
+  }
+
+  .site-footer__links {
+    justify-content: flex-end;
+  }
+
+  .site-footer__donate {
+    justify-items: end;
+  }
+
+  .site-footer__donate-links {
+    justify-content: flex-end;
+  }
+}
+
+@media (min-width: 1024px) {
+  .card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .about {
+    grid-template-columns: 1.05fr 0.95fr;
+  }
+
+  .hero__highlights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .project-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .project-card__info {
+    align-items: flex-start;
+  }
+}

--- a/data/social-links.json
+++ b/data/social-links.json
@@ -4,6 +4,6 @@
     "linkedin": "https://www.linkedin.com/in/nguyen-binh-minh-jm",
     "twitter": "https://x.com/js_minh",
     "youtube": "https://www.youtube.com/channel/UCkt3Mhwb3bduqwtRDZtjvsg",
-    "patreon": "https://www.patreon.com/cw/u16604577"
+    "patreon": "https://www.patreon.com/c/u16604577"
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Joshi Minh · Software · AI · Design</title>
+    <meta
+      name="description"
+      content="Portfolio of Joshi Minh – software engineer and vibe coder building human-centered experiences across full-stack web, AI systems, and visual design."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <script src="https://unpkg.com/lucide@0.379.0/dist/umd/lucide.min.js" defer></script>
+    <script src="assets/script.js" defer></script>
+  </head>
+  <body>
+    <div class="page" id="top">
+      <header class="hero" aria-labelledby="intro-heading">
+        <div class="hero__background" aria-hidden="true">
+          <span class="blur-ball blur-ball--primary"></span>
+          <span class="blur-ball blur-ball--secondary"></span>
+          <span class="blur-ball blur-ball--accent"></span>
+        </div>
+        <div class="hero__content">
+          <div class="hero__text">
+            <div class="status-pill">
+              <span class="status-pill__dot" aria-hidden="true"></span>
+              <span class="status-pill__text">Joshi Minh · Software · AI · Design</span>
+            </div>
+            <h1 id="intro-heading" class="hero__title">
+              Hi, I'm <span class="text-gradient">Joshi Minh</span>.
+            </h1>
+            <p class="hero__lead">
+              I'm a software engineer and vibe coder building human-centered experiences across full-stack web, AI systems,
+              and visual design. I love taking ideas from messy sketch to polished product.
+            </p>
+            <div class="hero__actions">
+              <a class="button button--primary" href="https://www.linkedin.com/in/nguyen-binh-minh-jm" target="_blank" rel="noopener noreferrer">
+                <i data-lucide="rocket" aria-hidden="true"></i>
+                <span>Get in touch</span>
+              </a>
+              <a class="button button--outline" href="#projects">
+                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path
+                    fill="currentColor"
+                    d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.387.6.111.82-.261.82-.577 0-.287-.01-1.244-.015-2.444-3.338.724-4.043-1.61-4.043-1.61-.546-1.385-1.333-1.754-1.333-1.754-1.089-.745.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.807 1.305 3.492.998.108-.775.418-1.305.76-1.605-2.665-.303-5.466-1.335-5.466-5.93 0-1.31.469-2.381 1.236-3.221-.124-.304-.536-1.524.117-3.176 0 0 1.008-.322 3.3 1.23a11.52 11.52 0 0 1 3.003-.404c1.02.005 2.044.138 3.003.404 2.29-1.552 3.295-1.23 3.295-1.23.653 1.653.241 2.873.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.61-2.807 5.624-5.479 5.921.43.372.823 1.105.823 2.226 0 1.606-.014 2.898-.014 3.293 0 .319.216.694.825.576C20.565 22.092 24 17.592 24 12.297 24 5.373 18.627 0 12 .297Z"
+                  />
+                </svg>
+                <span>View projects</span>
+              </a>
+            </div>
+            <div class="hero__highlights" id="hero-highlights"></div>
+            <div class="hero__social">
+              <span class="hero__social-label">Connect</span>
+              <div class="hero__social-buttons" id="social-buttons"></div>
+            </div>
+            <div class="hero__support">
+              <span class="hero__support-label">Support</span>
+              <div class="hero__support-buttons" id="donation-buttons"></div>
+            </div>
+          </div>
+          <div class="hero__card">
+            <article class="feature-card" aria-labelledby="feature-heading">
+              <div class="feature-card__glow" aria-hidden="true"></div>
+              <header class="feature-card__header">
+                <h2 id="feature-heading">Designing experiences for humans</h2>
+                <p>
+                  I'm currently exploring how AI can extend craftsmanship. From idea validation to launch-ready products, I love
+                  pairing rigorous systems thinking with a strong sense of vibe.
+                </p>
+              </header>
+              <div class="feature-card__list" id="focus-areas"></div>
+              <div class="feature-card__chips" id="focus-chips"></div>
+            </article>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section class="section" aria-labelledby="expertise-heading">
+          <div class="section__intro">
+            <h2 id="expertise-heading">What I do</h2>
+            <p>
+              I move comfortably between shipping reliable software, experimenting with machine intelligence, and shaping design
+              systems that make teams faster.
+            </p>
+          </div>
+          <div class="card-grid" id="expertise-grid"></div>
+        </section>
+
+        <section class="section section--projects" id="projects" aria-labelledby="projects-heading">
+          <div class="section__intro">
+            <span class="pill">Projects</span>
+            <h2 id="projects-heading">Featured builds &amp; explorations</h2>
+            <p>
+              Each project is a playground for new ideas—ranging from indie SaaS products to delightful experiments that push my
+              understanding of what's possible.
+            </p>
+          </div>
+          <div class="card-grid card-grid--projects" id="project-grid"></div>
+          <p class="section__note">Links open in a new tab.</p>
+        </section>
+
+        <section class="section section--about" aria-labelledby="about-heading">
+          <div class="about">
+            <div class="about__text">
+              <h2 id="about-heading">About me</h2>
+              <p>
+                Hey! I'm Joshi Minh—a developer who lives at the intersection of software engineering, AI experimentation, and
+                thoughtful design. I thrive on turning fuzzy ideas into systems that feel alive and intentional.
+              </p>
+              <p>
+                Whether it's crafting intelligent tooling, building full-stack products, or hosting build-in-public jams, I love
+                working with curious teams who care about people as much as pixels.
+              </p>
+              <ul class="about__values" id="core-values"></ul>
+              <a class="button button--primary" href="https://www.linkedin.com/in/nguyen-binh-minh-jm" target="_blank" rel="noopener noreferrer">
+                Let's collaborate
+              </a>
+            </div>
+            <article class="work-card" aria-labelledby="work-style-heading">
+              <div class="work-card__glow" aria-hidden="true"></div>
+              <header>
+                <h3 id="work-style-heading">How I work</h3>
+                <p>Intentional systems, rapid iteration, and empathy for the humans in the loop.</p>
+              </header>
+              <div class="work-card__list" id="work-style"></div>
+              <div class="work-card__chips" id="work-chips"></div>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer class="site-footer">
+        <div class="site-footer__content">
+          <div>
+            <p>Thanks for visiting my little corner of the internet. Let's build something incredible together.</p>
+            <p class="site-footer__meta">© 2025 Joshi Minh. Built with ❤️ and plenty of ☕.</p>
+          </div>
+          <div class="site-footer__actions">
+            <div class="site-footer__links" id="footer-links"></div>
+            <div class="site-footer__donate">
+              <span class="site-footer__donate-label">Support</span>
+              <div class="site-footer__donate-links" id="footer-donations"></div>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Ko-fi and Patreon donation buttons to the hero and footer in both the static and Next.js implementations
- extend the static assets to render the donation links with dedicated styling and corrected Patreon URL
- update shared social metadata to point to the new Patreon address

## Testing
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68cbcd2f85b883308746cc1d521754f6